### PR TITLE
Removed @types/dotenv dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,6 @@
     "dotenv": "^16.0.3"
   },
   "devDependencies": {
-    "@types/dotenv": "^8.2.0",
     "@types/jest": "^29.2.6",
     "@types/node": "^18.11.18",
     "@typescript-eslint/eslint-plugin": "^5.48.2",


### PR DESCRIPTION
Removed unnecessary dependency

`warning @types/dotenv@8.2.0: This is a stub types definition. dotenv provides its own type definitions, so you do not need this installed.`